### PR TITLE
Fix database module exports

### DIFF
--- a/backend/src/config/db.js
+++ b/backend/src/config/db.js
@@ -1,6 +1,6 @@
 import { Sequelize } from "sequelize";
 
-const sequelize = new Sequelize(
+export const sequelize = new Sequelize(
   process.env.DB_NAME,
   process.env.DB_USER,
   process.env.DB_PASSWORD,
@@ -12,4 +12,12 @@ const sequelize = new Sequelize(
   }
 );
 
-export default sequelize;
+export async function connectDB() {
+  try {
+    await sequelize.authenticate();
+    console.log("✅ Conexión a la base de datos establecida");
+  } catch (error) {
+    console.error("❌ No se pudo conectar a la base de datos", error);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- export the configured Sequelize instance so the models can import it correctly
- add a `connectDB` helper that authenticates the connection and fails fast when the database is unreachable

## Testing
- DB_HOST=localhost DB_PORT=3306 DB_NAME=test DB_USER=test DB_PASSWORD=test npm start *(fails: cannot connect to database without a running MySQL service)*

------
https://chatgpt.com/codex/tasks/task_e_68c994415328832f8f582b48f64f2ddf