### PR TITLE
Add React frontend for orders and products management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,93 @@
+# Technical Test - Orders Management
+
+This repository contains a full-stack solution for managing products and orders. The backend exposes a REST API built with Express, Sequelize, and MySQL, while the frontend is a React SPA created with Vite that consumes the API.
+
+## Project structure
+
+```
+.
+├── backend/   # Express + Sequelize API
+└── frontend/  # React UI built with Vite
+```
+
+## Backend
+
+### Environment variables
+
+Copy `backend/.env.example` to `backend/.env` and adjust the values to point to your MySQL instance:
+
+```
+DB_HOST=localhost
+DB_PORT=3306
+DB_NAME=orders_db
+DB_USER=root
+DB_PASSWORD=secret
+PORT=4000
+```
+
+### Install dependencies
+
+```bash
+cd backend
+npm install
+```
+
+### Database setup
+
+Make sure the configured MySQL database exists. The application uses Sequelize to create the required tables on startup. You can optionally run `node src/seed.js` to populate initial data.
+
+### Run the API
+
+```bash
+npm run dev
+```
+
+The API will be available at `http://localhost:4000`. Useful endpoints include:
+
+- `GET /api/products` – list products
+- `POST /api/products` – create a product
+- `PUT /api/products/:id` – update a product
+- `DELETE /api/products/:id` – remove a product
+- `GET /api/orders` – list orders with items
+- `POST /api/orders` – create an order with items
+- `PUT /api/orders/:id` – edit an order (unless completed)
+- `PATCH /api/orders/:id/status` – update status (`Pending`, `InProgress`, `Completed`)
+- `DELETE /api/orders/:id` – delete an order (unless completed)
+
+## Frontend
+
+### Install dependencies
+
+```bash
+cd frontend
+npm install
+```
+
+> **Note:** Installing dependencies requires access to the npm registry. If the command fails (for example in restricted environments), install the packages when network access is available.
+
+### Configure environment
+
+The UI expects the API to be available at `http://localhost:4000/api`. If you expose the backend elsewhere, create a `.env` file inside `frontend/` and set:
+
+```
+VITE_API_BASE_URL=http://your-host:port/api
+```
+
+### Run the UI
+
+```bash
+npm run dev
+```
+
+The application will start at `http://localhost:5173`.
+
+## Features
+
+- Orders list with totals, status badges, editing, deletion, and status changes.
+- Unified form to create or edit orders with automatic calculations, product management, and safeguards for completed orders.
+- Product catalog maintenance (CRUD) from the UI.
+- Shared modals, formatting helpers, and responsive styling for a clean experience.
+
+## Testing
+
+Automated tests are not included. You can interact with the UI locally and verify API responses using tools such as Postman or curl.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,6 @@
+DB_HOST=localhost
+DB_PORT=3306
+DB_NAME=orders_db
+DB_USER=root
+DB_PASSWORD=secret
+PORT=4000

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.dist
+.DS_Store
+vite.config.ts.timestamp-*
+dist
+.env

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Technical Test - Orders</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "technical-test-frontend",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2",
+    "prop-types": "^15.8.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.1",
+    "vite": "^5.4.8"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,27 @@
+import { NavLink, Navigate, Route, Routes } from "react-router-dom";
+import OrdersPage from "./pages/OrdersPage.jsx";
+import OrderFormPage from "./pages/OrderFormPage.jsx";
+import ProductsPage from "./pages/ProductsPage.jsx";
+
+export default function App() {
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <h1>Technical Test - Orders Management</h1>
+        <nav>
+          <NavLink to="/my-orders" className={({ isActive }) => (isActive ? "active" : "")}>Orders</NavLink>
+          <NavLink to="/products" className={({ isActive }) => (isActive ? "active" : "")}>Products</NavLink>
+        </nav>
+      </header>
+      <main className="app-main">
+        <Routes>
+          <Route path="/my-orders" element={<OrdersPage />} />
+          <Route path="/add-order" element={<OrderFormPage />} />
+          <Route path="/add-order/:id" element={<OrderFormPage />} />
+          <Route path="/products" element={<ProductsPage />} />
+          <Route path="*" element={<Navigate to="/my-orders" replace />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,0 +1,24 @@
+const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:4000/api";
+
+async function request(path, options = {}) {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    headers: { "Content-Type": "application/json", ...(options.headers || {}) },
+    ...options
+  });
+
+  if (!res.ok) {
+    const message = await res.text();
+    throw new Error(message || res.statusText);
+  }
+
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+export const api = {
+  get: (path) => request(path),
+  post: (path, body) => request(path, { method: "POST", body: JSON.stringify(body) }),
+  put: (path, body) => request(path, { method: "PUT", body: JSON.stringify(body) }),
+  patch: (path, body) => request(path, { method: "PATCH", body: JSON.stringify(body) }),
+  delete: (path) => request(path, { method: "DELETE" })
+};

--- a/frontend/src/components/Modal.jsx
+++ b/frontend/src/components/Modal.jsx
@@ -1,0 +1,27 @@
+import PropTypes from "prop-types";
+
+export default function Modal({ title, children, onClose, actions }) {
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true">
+      <div className="modal-content">
+        <header>
+          <h3>{title}</h3>
+        </header>
+        <div>{children}</div>
+        <div className="modal-actions">
+          {actions}
+          <button type="button" className="secondary" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Modal.propTypes = {
+  title: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  onClose: PropTypes.func.isRequired,
+  actions: PropTypes.node
+};

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,0 +1,14 @@
+export const ORDER_STATUSES = ["Pending", "InProgress", "Completed"];
+
+export function formatCurrency(value) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD"
+  }).format(Number(value || 0));
+}
+
+export function formatDate(value) {
+  if (!value) return "";
+  const date = typeof value === "string" ? new Date(value) : value;
+  return date.toLocaleString();
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App.jsx";
+import "./styles/global.css";
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/OrderFormPage.jsx
+++ b/frontend/src/pages/OrderFormPage.jsx
@@ -1,0 +1,315 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import Modal from "../components/Modal.jsx";
+import { api } from "../api/client.js";
+import { formatCurrency, formatDate } from "../constants.js";
+
+const emptyItem = { productId: "", qty: 1 };
+
+export default function OrderFormPage() {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const isEditing = Boolean(id);
+
+  const [orderNumber, setOrderNumber] = useState("");
+  const [orderDate, setOrderDate] = useState(new Date().toISOString());
+  const [orderStatus, setOrderStatus] = useState("Pending");
+  const [items, setItems] = useState([]);
+  const [products, setProducts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+  const [productModal, setProductModal] = useState(null);
+
+  const isCompleted = orderStatus === "Completed";
+
+  const totals = useMemo(() => {
+    const productsCount = items.reduce((acc, item) => acc + Number(item.qty || 0), 0);
+    const finalPrice = items.reduce((acc, item) => acc + Number(item.totalPrice || 0), 0);
+    return { productsCount, finalPrice };
+  }, [items]);
+
+  useEffect(() => {
+    const fetchInitialData = async () => {
+      setLoading(true);
+      try {
+        const [productsResponse, orderResponse] = await Promise.all([
+          api.get("/products"),
+          isEditing ? api.get(`/orders/${id}`) : Promise.resolve(null)
+        ]);
+
+        setProducts(productsResponse);
+
+        if (orderResponse) {
+          setOrderNumber(orderResponse.orderNumber);
+          setOrderDate(orderResponse.date);
+          setOrderStatus(orderResponse.status);
+          setItems(
+            (orderResponse.OrderItems || []).map((item) => ({
+              productId: item.productId,
+              productName: item.Product?.name || "",
+              unitPrice: Number(item.unitPrice),
+              qty: item.qty,
+              totalPrice: Number(item.totalPrice)
+            }))
+          );
+        } else {
+          setOrderDate(new Date().toISOString());
+          setOrderNumber(`ORD-${Date.now()}`);
+          setOrderStatus("Pending");
+          setItems([]);
+        }
+        setError(null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load resources");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchInitialData();
+  }, [id, isEditing]);
+
+  const openProductModal = (mode, initialItem = emptyItem, index = null) => {
+    const defaultProductId = initialItem.productId || (products[0]?.id ?? "");
+    setProductModal({
+      mode,
+      index,
+      productId: defaultProductId ? String(defaultProductId) : "",
+      qty: initialItem.qty || 1
+    });
+  };
+
+  const closeProductModal = () => setProductModal(null);
+
+  const handleSaveProduct = () => {
+    if (!productModal) return;
+    const product = products.find((p) => p.id === Number(productModal.productId));
+    if (!product) {
+      alert("Please select a product");
+      return;
+    }
+    const qty = Number(productModal.qty);
+    if (!Number.isInteger(qty) || qty <= 0) {
+      alert("Quantity must be a positive integer");
+      return;
+    }
+
+    const itemData = {
+      productId: product.id,
+      productName: product.name,
+      unitPrice: Number(product.unitPrice),
+      qty,
+      totalPrice: Number(product.unitPrice) * qty
+    };
+
+    setItems((prev) => {
+      if (productModal.mode === "edit" && productModal.index !== null) {
+        const updated = [...prev];
+        updated[productModal.index] = itemData;
+        return updated;
+      }
+      return [...prev, itemData];
+    });
+
+    closeProductModal();
+  };
+
+  const removeItem = (index) => {
+    if (isCompleted) return;
+    const confirmed = window.confirm("Remove product from order?");
+    if (!confirmed) return;
+    setItems((prev) => prev.filter((_, idx) => idx !== index));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (items.length === 0) {
+      alert("Please add at least one product to the order");
+      return;
+    }
+
+    try {
+      setSaving(true);
+      const payload = {
+        orderNumber,
+        items: items.map((item) => ({ productId: item.productId, qty: item.qty }))
+      };
+
+      if (isEditing) {
+        await api.put(`/orders/${id}`, payload);
+      } else {
+        await api.post("/orders", payload);
+      }
+
+      navigate("/my-orders");
+    } catch (err) {
+      alert(err.message || "Failed to save order");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="card">
+      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <h2>{isEditing ? "Edit Order" : "Add Order"}</h2>
+        <button className="secondary" type="button" onClick={() => navigate(-1)}>
+          Back
+        </button>
+      </header>
+
+      {loading && <p>Loading...</p>}
+      {error && <p style={{ color: "#dc2626" }}>{error}</p>}
+
+      {!loading && (
+        <form onSubmit={handleSubmit}>
+          {isCompleted && (
+            <p style={{ color: "#92400e", background: "#fef3c7", padding: "0.75rem", borderRadius: "6px" }}>
+              Completed orders cannot be edited. You can only view the details.
+            </p>
+          )}
+
+          <div className="form-grid">
+            <div className="form-field">
+              <label htmlFor="orderNumber">Order #</label>
+              <input
+                id="orderNumber"
+                value={orderNumber}
+                onChange={(event) => setOrderNumber(event.target.value)}
+                required
+                disabled={isCompleted}
+              />
+            </div>
+            <div className="form-field">
+              <label htmlFor="orderDate">Date</label>
+              <input
+                id="orderDate"
+                value={new Date(orderDate).toISOString().slice(0, 16)}
+                type="datetime-local"
+                disabled
+              />
+              <small style={{ color: "#6b7280" }}>Display: {formatDate(orderDate)}</small>
+            </div>
+            <div className="form-field">
+              <label>Status</label>
+              <input value={orderStatus} disabled readOnly />
+            </div>
+            <div className="form-field">
+              <label># Products</label>
+              <input value={totals.productsCount} disabled readOnly />
+            </div>
+            <div className="form-field">
+              <label>Final Price</label>
+              <input value={formatCurrency(totals.finalPrice)} disabled readOnly />
+            </div>
+          </div>
+
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1rem" }}>
+            <h3>Products</h3>
+            <button type="button" onClick={() => openProductModal("add")} disabled={isCompleted}>
+              Add product
+            </button>
+          </div>
+
+          {items.length === 0 ? (
+            <div className="empty-state">No products added yet.</div>
+          ) : (
+            <div style={{ overflowX: "auto" }}>
+              <table>
+                <thead>
+                  <tr>
+                    <th>ID</th>
+                    <th>Name</th>
+                    <th>Unit price</th>
+                    <th>Qty</th>
+                    <th>Total price</th>
+                    <th>Options</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((item, index) => (
+                    <tr key={`${item.productId}-${index}`}>
+                      <td>{item.productId}</td>
+                      <td>{item.productName}</td>
+                      <td>{formatCurrency(item.unitPrice)}</td>
+                      <td>{item.qty}</td>
+                      <td>{formatCurrency(item.totalPrice)}</td>
+                      <td>
+                        <div className="actions">
+                          <button
+                            type="button"
+                            className="secondary"
+                            onClick={() => openProductModal("edit", item, index)}
+                            disabled={isCompleted}
+                          >
+                            Edit
+                          </button>
+                          <button
+                            type="button"
+                            className="danger"
+                            onClick={() => removeItem(index)}
+                            disabled={isCompleted}
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          <div style={{ marginTop: "1.5rem", display: "flex", justifyContent: "flex-end", gap: "1rem" }}>
+            <button type="button" className="secondary" onClick={() => navigate("/my-orders")}>Cancel</button>
+            <button type="submit" disabled={saving || isCompleted}>
+              {isEditing ? "Update order" : "Create order"}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {productModal && (
+        <Modal
+          title={productModal.mode === "edit" ? "Edit product" : "Add product"}
+          onClose={closeProductModal}
+          actions={
+            <button type="button" onClick={handleSaveProduct}>
+              Save
+            </button>
+          }
+        >
+          <div className="form-field">
+            <label htmlFor="productSelect">Product</label>
+            <select
+              id="productSelect"
+              value={productModal.productId}
+              onChange={(event) => setProductModal((prev) => ({ ...prev, productId: event.target.value }))}
+            >
+              <option value="" disabled>
+                Select a product
+              </option>
+              {products.map((product) => (
+                <option key={product.id} value={product.id}>
+                  {product.name} — {formatCurrency(product.unitPrice)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="form-field">
+            <label htmlFor="productQty">Quantity</label>
+            <input
+              id="productQty"
+              type="number"
+              min={1}
+              value={productModal.qty}
+              onChange={(event) => setProductModal((prev) => ({ ...prev, qty: event.target.value }))}
+            />
+          </div>
+        </Modal>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/OrdersPage.jsx
+++ b/frontend/src/pages/OrdersPage.jsx
@@ -1,0 +1,169 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Modal from "../components/Modal.jsx";
+import { api } from "../api/client.js";
+import { ORDER_STATUSES, formatCurrency, formatDate } from "../constants.js";
+
+const STATUS_LABEL = {
+  Pending: "Pending",
+  InProgress: "In Progress",
+  Completed: "Completed"
+};
+
+export default function OrdersPage() {
+  const navigate = useNavigate();
+  const [orders, setOrders] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [statusModal, setStatusModal] = useState(null);
+
+  const loadOrders = async () => {
+    setLoading(true);
+    try {
+      const data = await api.get("/orders");
+      setOrders(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load orders");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadOrders();
+  }, []);
+
+  const handleDelete = async (order) => {
+    if (order.status === "Completed") return;
+    const confirmed = window.confirm(`Delete order ${order.orderNumber}?`);
+    if (!confirmed) return;
+    try {
+      await api.delete(`/orders/${order.id}`);
+      await loadOrders();
+    } catch (err) {
+      alert(err.message || "Failed to delete order");
+    }
+  };
+
+  const openStatusModal = (order) => {
+    setStatusModal({ order, status: order.status });
+  };
+
+  const updateStatus = async () => {
+    if (!statusModal) return;
+    try {
+      await api.patch(`/orders/${statusModal.order.id}/status`, { status: statusModal.status });
+      setStatusModal(null);
+      await loadOrders();
+    } catch (err) {
+      alert(err.message || "Failed to update status");
+    }
+  };
+
+  const totalSummary = useMemo(() => {
+    const totalOrders = orders.length;
+    const totalAmount = orders.reduce((acc, ord) => acc + Number(ord.finalPrice || 0), 0);
+    const completed = orders.filter((ord) => ord.status === "Completed").length;
+    return { totalOrders, totalAmount, completed };
+  }, [orders]);
+
+  return (
+    <section className="card">
+      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <div>
+          <h2>My Orders</h2>
+          <p style={{ margin: 0, color: "#6b7280" }}>
+            {totalSummary.totalOrders} orders • {totalSummary.completed} completed • Total {formatCurrency(totalSummary.totalAmount)}
+          </p>
+        </div>
+        <button onClick={() => navigate("/add-order")}>Add order</button>
+      </header>
+
+      {loading && <p>Loading orders...</p>}
+      {error && <p style={{ color: "#dc2626" }}>{error}</p>}
+
+      {!loading && orders.length === 0 && <div className="empty-state">No orders yet. Create your first order.</div>}
+
+      {!loading && orders.length > 0 && (
+        <div style={{ overflowX: "auto" }}>
+          <table>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Order #</th>
+                <th>Status</th>
+                <th>Date</th>
+                <th># Products</th>
+                <th>Final price</th>
+                <th>Options</th>
+              </tr>
+            </thead>
+            <tbody>
+              {orders.map((order) => (
+                <tr key={order.id}>
+                  <td>{order.id}</td>
+                  <td>{order.orderNumber}</td>
+                  <td>
+                    <span className={`badge ${order.status}`}>{STATUS_LABEL[order.status]}</span>
+                  </td>
+                  <td>{formatDate(order.date)}</td>
+                  <td>{order.productsCount}</td>
+                  <td>{formatCurrency(order.finalPrice)}</td>
+                  <td>
+                    <div className="actions">
+                      <button
+                        className="secondary"
+                        onClick={() => navigate(`/add-order/${order.id}`)}
+                        disabled={order.status === "Completed"}
+                      >
+                        Edit
+                      </button>
+                      <button
+                        className="danger"
+                        onClick={() => handleDelete(order)}
+                        disabled={order.status === "Completed"}
+                      >
+                        Delete
+                      </button>
+                      <button onClick={() => openStatusModal(order)} disabled={order.status === "Completed"}>
+                        Change status
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {statusModal && (
+        <Modal
+          title={`Update status for ${statusModal.order.orderNumber}`}
+          onClose={() => setStatusModal(null)}
+          actions={
+            <button type="button" onClick={updateStatus}>
+              Save
+            </button>
+          }
+        >
+          <div className="form-field">
+            <label htmlFor="status">Status</label>
+            <select
+              id="status"
+              value={statusModal.status}
+              onChange={(event) => setStatusModal((prev) => ({ ...prev, status: event.target.value }))}
+            >
+              {ORDER_STATUSES.map((status) => (
+                <option key={status} value={status}>
+                  {STATUS_LABEL[status]}
+                </option>
+              ))}
+            </select>
+          </div>
+        </Modal>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/ProductsPage.jsx
+++ b/frontend/src/pages/ProductsPage.jsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from "react";
+import Modal from "../components/Modal.jsx";
+import { api } from "../api/client.js";
+import { formatCurrency } from "../constants.js";
+
+export default function ProductsPage() {
+  const [products, setProducts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [modal, setModal] = useState(null);
+
+  const loadProducts = async () => {
+    setLoading(true);
+    try {
+      const data = await api.get("/products");
+      setProducts(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load products");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadProducts();
+  }, []);
+
+  const openModal = (mode, product = { name: "", unitPrice: 0 }) => {
+    setModal({
+      mode,
+      id: product.id ?? null,
+      name: product.name,
+      unitPrice: product.unitPrice
+    });
+  };
+
+  const closeModal = () => setModal(null);
+
+  const saveProduct = async () => {
+    if (!modal) return;
+    if (!modal.name.trim()) {
+      alert("Name is required");
+      return;
+    }
+    const unitPrice = Number(modal.unitPrice);
+    if (Number.isNaN(unitPrice) || unitPrice <= 0) {
+      alert("Unit price must be greater than zero");
+      return;
+    }
+    try {
+      if (modal.mode === "edit" && modal.id) {
+        await api.put(`/products/${modal.id}`, { name: modal.name, unitPrice });
+      } else {
+        await api.post("/products", { name: modal.name, unitPrice });
+      }
+      closeModal();
+      await loadProducts();
+    } catch (err) {
+      alert(err.message || "Failed to save product");
+    }
+  };
+
+  const deleteProduct = async (product) => {
+    const confirmed = window.confirm(`Delete product ${product.name}?`);
+    if (!confirmed) return;
+    try {
+      await api.delete(`/products/${product.id}`);
+      await loadProducts();
+    } catch (err) {
+      alert(err.message || "Failed to delete product");
+    }
+  };
+
+  return (
+    <section className="card">
+      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <h2>Products</h2>
+        <button type="button" onClick={() => openModal("create")}>Add product</button>
+      </header>
+
+      {loading && <p>Loading products...</p>}
+      {error && <p style={{ color: "#dc2626" }}>{error}</p>}
+
+      {!loading && products.length === 0 && <div className="empty-state">No products available.</div>}
+
+      {!loading && products.length > 0 && (
+        <div style={{ overflowX: "auto" }}>
+          <table>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Unit price</th>
+                <th>Options</th>
+              </tr>
+            </thead>
+            <tbody>
+              {products.map((product) => (
+                <tr key={product.id}>
+                  <td>{product.id}</td>
+                  <td>{product.name}</td>
+                  <td>{formatCurrency(product.unitPrice)}</td>
+                  <td>
+                    <div className="actions">
+                      <button
+                        type="button"
+                        className="secondary"
+                        onClick={() => openModal("edit", product)}
+                      >
+                        Edit
+                      </button>
+                      <button type="button" className="danger" onClick={() => deleteProduct(product)}>
+                        Delete
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {modal && (
+        <Modal
+          title={modal.mode === "edit" ? "Edit product" : "Add product"}
+          onClose={closeModal}
+          actions={
+            <button type="button" onClick={saveProduct}>
+              Save
+            </button>
+          }
+        >
+          <div className="form-field">
+            <label htmlFor="productName">Name</label>
+            <input
+              id="productName"
+              value={modal.name}
+              onChange={(event) => setModal((prev) => ({ ...prev, name: event.target.value }))}
+            />
+          </div>
+          <div className="form-field">
+            <label htmlFor="productPrice">Unit price</label>
+            <input
+              id="productPrice"
+              type="number"
+              min="0"
+              step="0.01"
+              value={modal.unitPrice}
+              onChange={(event) => setModal((prev) => ({ ...prev, unitPrice: event.target.value }))}
+            />
+          </div>
+        </Modal>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,212 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #1a1a1a;
+  background-color: #f3f4f6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  background-color: #1f2937;
+  color: #fff;
+  padding: 1.5rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.app-header nav {
+  display: flex;
+  gap: 1rem;
+}
+
+.app-header a {
+  color: #e5e7eb;
+  text-decoration: none;
+  padding: 0.25rem 0.75rem;
+  border-radius: 6px;
+  transition: background-color 0.2s ease;
+}
+
+.app-header a:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.app-header a.active {
+  background-color: #2563eb;
+  color: white;
+}
+
+.app-main {
+  flex: 1;
+  padding: 2rem;
+}
+
+.card {
+  background-color: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.1);
+  padding: 1.5rem;
+}
+
+.card h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background-color: #f3f4f6;
+}
+
+th,
+td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+tbody tr:hover {
+  background-color: #f9fafb;
+}
+
+button {
+  cursor: pointer;
+  border: none;
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  background-color: #2563eb;
+  color: white;
+  font-weight: 600;
+  transition: background-color 0.2s ease;
+}
+
+button.secondary {
+  background-color: #6b7280;
+}
+
+button.danger {
+  background-color: #dc2626;
+}
+
+button:disabled {
+  background-color: #9ca3af;
+  cursor: not-allowed;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-field label {
+  font-weight: 600;
+}
+
+input,
+select {
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid #d1d5db;
+  font-size: 1rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.badge.Pending {
+  background-color: #fef3c7;
+  color: #92400e;
+}
+
+.badge.InProgress {
+  background-color: #dbeafe;
+  color: #1d4ed8;
+}
+
+.badge.Completed {
+  background-color: #dcfce7;
+  color: #166534;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 12px;
+  padding: 1.5rem;
+  width: min(480px, 90vw);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.empty-state {
+  padding: 2rem;
+  text-align: center;
+  color: #6b7280;
+}
+
+@media (max-width: 720px) {
+  .app-main {
+    padding: 1rem;
+  }
+
+  th,
+  td {
+    padding: 0.5rem 0.75rem;
+  }
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    open: true
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a new Vite-based React frontend with routing, styling, and reusable utilities
- implement order listing, status updates, and guarded editing along with an add/edit order flow with product modals
- add product maintenance screen plus documentation and environment sample for running the stack

## Testing
- not run (npm registry access was blocked in the environment)

------
https://chatgpt.com/codex/tasks/task_e_68e440d58274832f8fabfdf754079a6d